### PR TITLE
Less allocations, more laziness

### DIFF
--- a/pythonx/clap/fuzzymatch-rs/src/lib.rs
+++ b/pythonx/clap/fuzzymatch-rs/src/lib.rs
@@ -12,20 +12,29 @@ fn find_start_at<'a, P: Pattern<'a>>(slice: &'a str, at: usize, pat: P) -> Optio
 }
 
 fn substr_scorer(niddle: &str, haystack: &str) -> Option<(f64, Vec<usize>)> {
-    let niddle = niddle.to_lowercase();
     let haystack = haystack.to_lowercase();
-    let indices: Vec<usize> = (0..haystack.len()).collect();
     let haystack = haystack.as_str();
 
     let mut offset = 0;
     let mut positions = Vec::new();
     for sub_niddle in niddle.split_whitespace() {
-        match find_start_at(haystack, offset, sub_niddle) {
+        let sub_niddle = sub_niddle.to_lowercase();
+        
+        match find_start_at(haystack, offset, &sub_niddle) {
             Some(idx) => {
-                offset = idx;
-                let niddle_len = sub_niddle.len();
-                positions.extend_from_slice(&indices[offset..offset + niddle_len]);
-                offset += niddle_len;
+                offset = idx + sub_niddle.len();
+                // For build without overflow checks this could be written as
+                // `let mut pos = idx - 1;` with `|| { pos += 1; pos }` closure.
+                let mut pos = idx;
+                positions.resize_with(
+                    positions.len() + sub_niddle.len(),
+                    // Simple endless iterator for `idx..` range. Even though it's endless,
+                    // it will iterate only `sub_niddle.len()` times.
+                    || {
+                        pos += 1;
+                        pos - 1
+                    },
+                );
             }
             None => return None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,10 +77,10 @@ pub fn main() {
 
     if let Some(number) = opt.number {
         let total = ranked.len();
-        let payload = ranked.into_iter().take(number).collect::<Vec<_>>();
+        let payload = ranked.into_iter().take(number);
         let mut lines = Vec::with_capacity(number);
         let mut indices = Vec::with_capacity(number);
-        for (text, _, idxs) in payload.iter() {
+        for (text, _, idxs) in payload {
             lines.push(text);
             indices.push(idxs);
         }


### PR DESCRIPTION
If `find_start_at()` returns `None`, the function instantly returns `None` too. So instead of lowercasing the whole string and then splitting it into words, split it and then lowercase given words. Less lowercasing if `find_start_at()` will exit early.

Also removed vector of indices. Those could be created in place, so no need for allocation of the whole vector. Besides, `vec.extend_from_slice(slice)` desugars into something like this:

for element in slice.iter().cloned() {
    vec.push(element);
}